### PR TITLE
Update Kotlin version to latest - 1.3.21

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@
 
 plugins {
     // Apply the Kotlin JVM plugin to add support for Kotlin on the JVM.
-    id("org.jetbrains.kotlin.jvm").version("1.3.11")
+    id("org.jetbrains.kotlin.jvm").version("1.3.21")
 }
 
 repositories {


### PR DESCRIPTION
This version fixes the build, removing the following warnings:

```
$ ./gradlew check
...
Deprecated Gradle features were used in this build, making it
incompatible with Gradle 6.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See
https://docs.gradle.org/5.1.1/userguide/command_line_interface.html#sec:command_line_warnings
...
$ ./gradlew check  --warning-mode all
...
The DefaultSourceDirectorySet constructor has been deprecated. This is
scheduled to be removed in Gradle 6.0. Please use the ObjectFactory
service to create instances of SourceDirectorySet instead.
...
```