### PR TITLE
Ignore IntelliJ IDEA and VIM artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,10 @@
 
 # Ignore Gradle build output directory
 build
+
+# Ignore IntelliJ IDEA project-specific settings and build directory
+.idea/
+out/
+
+# Ignore vim temporary files
+*.swp


### PR DESCRIPTION
Add IntelliJ IDEA project-specific settings to .gitignore, making the
project "IDE agnostic" instead of "IDE specific".
This might change later if we find some settings beneficial, but as
rule of thumb we will prefer "repository-quality" checks on our
Continuous Integration or a standard that is common between multiple
IDEs/Editors (e.g.: https://editorconfig.org).

Ignore Intellij IDEA build folders. Default build artifacts might still
be destributed, but they should use another platform (see: Countious
Delivery) since they should never be version-controlled.

Lastly, ignore VIM temporary files to avoid accidentally commiting them
to the repository.